### PR TITLE
Harden emulator against untrusted/malformed CSI args and edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  vet:
+    name: go vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - run: go vet ./...
+
+  test:
+    name: go test -race
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - run: go test -race -timeout 5m ./...
+
+  fuzz:
+    name: FuzzWrite smoke (30s)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run fuzz smoke
+        run: go test -run=^$ -fuzz=FuzzWrite -fuzztime=30s
+
+      - name: Upload fuzz failure corpus
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-failure-corpus
+          path: testdata/fuzz/**
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+### Go template
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+.DS_Store
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: go
-
-go:
-  - "1.10.2"
-  - master

--- a/csi.go
+++ b/csi.go
@@ -107,7 +107,8 @@ func (t *State) handleCSI() {
 	case 'H', 'f': // CUP, HVP - move to <row> <col>
 		t.moveAbsTo(c.arg(1, 1)-1, c.arg(0, 1)-1)
 	case 'I': // CHT - cursor forward tabulation <n> tab stops
-		n := c.arg(0, 1)
+		// Clamp to cols: putTab stops at the margin, so more iterations are wasted work and would hang on INT_MAX.
+		n := clamp(c.arg(0, 1), 0, t.cols)
 		for i := 0; i < n; i++ {
 			t.putTab(true)
 		}
@@ -153,7 +154,8 @@ func (t *State) handleCSI() {
 	case 'P': // DCH - delete <n> chars
 		t.deleteChars(c.arg(0, 1))
 	case 'Z': // CBT - cursor backward tabulation <n> tab stops
-		n := c.arg(0, 1)
+		// Clamp: see CHT above.
+		n := clamp(c.arg(0, 1), 0, t.cols)
 		for i := 0; i < n; i++ {
 			t.putTab(false)
 		}

--- a/csi.go
+++ b/csi.go
@@ -32,6 +32,12 @@ func (c *csiEscape) put(b byte) bool {
 }
 
 func (c *csiEscape) parse() {
+	if len(c.buf) == 0 {
+		c.mode = 0
+		c.args = c.args[:0]
+		c.priv = false
+		return
+	}
 	c.mode = c.buf[len(c.buf)-1]
 	if len(c.buf) == 1 {
 		return
@@ -41,6 +47,9 @@ func (c *csiEscape) parse() {
 	if s[0] == '?' {
 		c.priv = true
 		s = s[1:]
+	}
+	if len(s) == 0 {
+		return
 	}
 	s = s[:len(s)-1]
 	ss := strings.Split(s, ";")
@@ -74,26 +83,28 @@ func (t *State) handleCSI() {
 	case '@': // ICH - insert <n> blank char
 		t.insertBlanks(c.arg(0, 1))
 	case 'A': // CUU - cursor <n> up
-		t.moveTo(t.cur.X, t.cur.Y-c.maxarg(0, 1))
+		t.moveTo(t.cur.X, t.cur.Y-clamp(c.maxarg(0, 1), 1, t.rows))
 	case 'B', 'e': // CUD, VPR - cursor <n> down
-		t.moveTo(t.cur.X, t.cur.Y+c.maxarg(0, 1))
+		t.moveTo(t.cur.X, t.cur.Y+clamp(c.maxarg(0, 1), 1, t.rows))
 	case 'c': // DA - device attributes
 		if c.arg(0, 0) == 0 {
 			// TODO: write vt102 id
 		}
 	case 'C', 'a': // CUF, HPR - cursor <n> forward
-		t.moveTo(t.cur.X+c.maxarg(0, 1), t.cur.Y)
+		t.moveTo(t.cur.X+clamp(c.maxarg(0, 1), 1, t.cols), t.cur.Y)
 	case 'D': // CUB - cursor <n> backward
-		t.moveTo(t.cur.X-c.maxarg(0, 1), t.cur.Y)
+		t.moveTo(t.cur.X-clamp(c.maxarg(0, 1), 1, t.cols), t.cur.Y)
 	case 'E': // CNL - cursor <n> down and first col
-		t.moveTo(0, t.cur.Y+c.arg(0, 1))
+		t.moveTo(0, t.cur.Y+clamp(c.arg(0, 1), 0, t.rows))
 	case 'F': // CPL - cursor <n> up and first col
-		t.moveTo(0, t.cur.Y-c.arg(0, 1))
+		t.moveTo(0, t.cur.Y-clamp(c.arg(0, 1), 0, t.rows))
 	case 'g': // TBC - tabulation clear
 		switch c.arg(0, 0) {
 		// clear current tab stop
 		case 0:
-			t.tabs[t.cur.X] = false
+			if t.cur.X >= 0 && t.cur.X < len(t.tabs) {
+				t.tabs[t.cur.X] = false
+			}
 		// clear all tabs
 		case 3:
 			for i := range t.tabs {
@@ -150,7 +161,8 @@ func (t *State) handleCSI() {
 	case 'M': // DL - delete <n> lines
 		t.deleteLines(c.arg(0, 1))
 	case 'X': // ECH - erase <n> chars
-		t.clear(t.cur.X, t.cur.Y, t.cur.X+c.arg(0, 1)-1, t.cur.Y)
+		n := clamp(c.arg(0, 1), 1, t.cols-t.cur.X)
+		t.clear(t.cur.X, t.cur.Y, t.cur.X+n-1, t.cur.Y)
 	case 'P': // DCH - delete <n> chars
 		t.deleteChars(c.arg(0, 1))
 	case 'Z': // CBT - cursor backward tabulation <n> tab stops
@@ -160,12 +172,15 @@ func (t *State) handleCSI() {
 			t.putTab(false)
 		}
 	case 'd': // VPA - move to <row>
-		t.moveAbsTo(t.cur.X, c.arg(0, 1)-1)
+		t.moveAbsTo(t.cur.X, max(c.arg(0, 1), 1)-1)
 	case 'h': // SM - set terminal mode
 		t.setMode(c.priv, true, c.args)
 	case 'm': // SGR - terminal attribute (color)
 		t.setAttr(c.args)
 	case 'n':
+		if t.w == nil {
+			break
+		}
 		switch c.arg(0, 0) {
 		case 5: // DSR - device status report
 			t.w.Write([]byte("\033[0n"))

--- a/hardening_test.go
+++ b/hardening_test.go
@@ -3,9 +3,48 @@ package vt10x
 import (
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestWriteRecoversPanicFromAnswerbackWriter(t *testing.T) {
+	const msg = "writer boom"
+	vt := New(WithWriter(panickingWriter{msg: msg}))
+	vt.Resize(80, 24)
+
+	// CSI 6n (device status report) makes vt10x write the cursor position back through its configured writer.
+	_, err := vt.Write([]byte("\x1b[6n"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), msg) {
+		t.Fatalf("error missing panic value: %v", err)
+	}
+	if !strings.Contains(err.Error(), "recovered panic") {
+		t.Fatalf("error missing prefix: %v", err)
+	}
+}
+
+func TestRecoverTo(t *testing.T) {
+	var err error
+	func() {
+		defer recoverTo(&err)
+		panic("kaboom")
+	}()
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	if !strings.Contains(err.Error(), "kaboom") {
+		t.Fatalf("error missing panic value: %v", err)
+	}
+	if !strings.Contains(err.Error(), "recovered panic") {
+		t.Fatalf("error missing prefix: %v", err)
+	}
+	if !strings.Contains(err.Error(), "goroutine") {
+		t.Fatalf("error missing stack trace: %v", err)
+	}
+}
 
 // TestNewZeroSizeNoPanic ensures constructing a terminal with a zero size does not panic. resize(0,0) is a no-op so the
 // internal state stays at cols=0/rows=0; reset() must tolerate that.
@@ -110,3 +149,7 @@ func FuzzWrite(f *testing.F) {
 		}
 	})
 }
+
+type panickingWriter struct{ msg string }
+
+func (p panickingWriter) Write([]byte) (int, error) { panic(p.msg) }

--- a/hardening_test.go
+++ b/hardening_test.go
@@ -1,6 +1,7 @@
 package vt10x
 
 import (
+	"bytes"
 	"fmt"
 	"math"
 	"strings"
@@ -62,6 +63,120 @@ func TestNewZeroSizeNoPanic(t *testing.T) {
 	}
 }
 
+func TestZeroSizeWriteNoPanic(t *testing.T) {
+	vt := New(WithSize(0, 0))
+	sequences := []string{
+		"plain text",
+		"\x1bH",
+		"\x1b[0g",
+		"\x1b[6n",
+		"\x1b]0;title\x07",
+	}
+
+	for _, seq := range sequences {
+		t.Run(fmt.Sprintf("%q", seq), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Write(%q) on zero-size terminal panicked: %v", seq, r)
+				}
+			}()
+
+			if _, err := vt.Write([]byte(seq)); err != nil {
+				t.Fatalf("Write(%q) returned error: %v", seq, err)
+			}
+		})
+	}
+}
+
+func TestZeroSizeWriteNoPanicSimple(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Write on 0-size terminal panicked: %v", r)
+		}
+	}()
+	vt := New(WithSize(0, 0))
+	vt.Write([]byte("hello\033[H\033[2J"))
+}
+
+func TestZeroSizeAltScreenNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("alt-screen on 0-size terminal panicked: %v", r)
+		}
+	}()
+	vt := New(WithSize(0, 0))
+	vt.Write([]byte("\033[?1049h\033[?1049l\033[?47h\033[?47l"))
+}
+
+func TestNilWriterNoPanic(t *testing.T) {
+	vt := New(WithWriter(nil))
+	sequences := []string{
+		"\x1b[5n",
+		"\x1b[6n",
+		"\x1b]10;?\x07",
+		"\x1b]11;?\x07",
+	}
+
+	for _, seq := range sequences {
+		t.Run(fmt.Sprintf("%q", seq), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Write(%q) with nil writer panicked: %v", seq, r)
+				}
+			}()
+
+			if _, err := vt.Write([]byte(seq)); err != nil {
+				t.Fatalf("Write(%q) returned error: %v", seq, err)
+			}
+		})
+	}
+}
+
+func TestZeroStateMutationHelpersNoPanic(t *testing.T) {
+	s := newState(nil)
+	steps := []struct {
+		name string
+		fn   func()
+	}{
+		{"putTab", func() { s.putTab(true) }},
+		{"clear", func() { s.clear(0, 0, 1, 1) }},
+		{"moveTo", func() { s.moveTo(10, 10) }},
+		{"scrollUp", func() { s.scrollUp(0, 1) }},
+		{"scrollDown", func() { s.scrollDown(0, 1) }},
+		{"insertBlanks", func() { s.insertBlanks(1) }},
+		{"deleteChars", func() { s.deleteChars(1) }},
+		{"oscColorResponse", func() { s.oscColorResponse(int(DefaultFG), 10) }},
+		{"osc4ColorResponse", func() { s.osc4ColorResponse(1) }},
+	}
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("%s panicked on zero state: %v", step.name, r)
+				}
+			}()
+			step.fn()
+		})
+	}
+}
+
+func TestNilWriterFallsBackToDiscard(t *testing.T) {
+	var buf bytes.Buffer
+	vt := New(WithWriter(&buf))
+	if _, err := vt.Write([]byte("\x1b[5n")); err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("expected DSR response to be written")
+	}
+
+	vt = New(WithWriter(nil))
+	if _, err := vt.Write([]byte("\x1b[5n")); err != nil {
+		t.Fatalf("Write returned error with nil writer: %v", err)
+	}
+}
+
 // TestResizeRejectsExtremeSizes ensures pathological resize requests are  rejected rather than blindly allocating
 // terabytes. The library is used to replay untrusted session recordings, so a malformed resize event must not be able
 // to OOM the auth server.
@@ -95,6 +210,73 @@ func TestResizeRejectsExtremeSizes(t *testing.T) {
 					tc.cols, tc.rows, cols, rows, maxResizeDim)
 			}
 		})
+	}
+}
+
+func TestECHOverflowNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ECH overflow panicked: %v", r)
+		}
+	}()
+	vt := New(WithSize(80, 24))
+	// Position at col 40 (1-indexed = col 39 0-indexed), then ECH with INT_MAX
+	seq := fmt.Sprintf("\033[1;40H\033[%dX", math.MaxInt)
+	vt.Write([]byte(seq))
+	cur := vt.Cursor()
+	// Cursor must stay at col 39 (0-indexed), not move to 0
+	if cur.X != 39 {
+		t.Errorf("cursor at col %d after ECH, want 39", cur.X)
+	}
+}
+
+func TestCursorMoveOverflowNoPanic(t *testing.T) {
+	cases := []struct {
+		name         string
+		seq          string
+		wantX, wantY int
+	}{
+		{"CUU INT_MAX", fmt.Sprintf("\033[12;40H\033[%dA", math.MaxInt), 39, 0},
+		{"CUD INT_MAX", fmt.Sprintf("\033[12;40H\033[%dB", math.MaxInt), 39, 23},
+		{"CUF INT_MAX", fmt.Sprintf("\033[12;40H\033[%dC", math.MaxInt), 79, 11},
+		{"CUB INT_MAX", fmt.Sprintf("\033[12;40H\033[%dD", math.MaxInt), 0, 11},
+		{"CNL INT_MAX", fmt.Sprintf("\033[12;40H\033[%dE", math.MaxInt), 0, 23},
+		{"CPL INT_MAX", fmt.Sprintf("\033[12;40H\033[%dF", math.MaxInt), 0, 0},
+		{"VPA 0", "\033[0d", 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("%s panicked: %v", tc.name, r)
+				}
+			}()
+			vt := New(WithSize(80, 24))
+			vt.Write([]byte(tc.seq))
+			cur := vt.Cursor()
+			if cur.X != tc.wantX || cur.Y != tc.wantY {
+				t.Errorf("cursor at (%d,%d), want (%d,%d)", cur.X, cur.Y, tc.wantX, tc.wantY)
+			}
+		})
+	}
+}
+
+// TestNonASCIIInCSI verifies that a non-ASCII rune whose low byte would dispatch
+// a CSI command (e.g. U+0148 low byte = 0x48 = 'H' = CUP) is discarded instead.
+func TestNonASCIIInCSI(t *testing.T) {
+	vt := New(WithSize(80, 24))
+	// Position cursor at col 5, row 5 (1-indexed: row 6, col 6)
+	vt.Write([]byte("\033[6;6H"))
+	cur := vt.Cursor()
+	if cur.X != 5 || cur.Y != 5 {
+		t.Fatalf("setup failed: cursor at (%d,%d), want (5,5)", cur.X, cur.Y)
+	}
+	// U+0148 encodes as \xc5\x88 in UTF-8; byte(0x0148) = 0x48 = 'H'
+	// Without the fix this dispatches CUP with no args → moves cursor to (0,0)
+	vt.Write([]byte("\033[\xc5\x88"))
+	cur = vt.Cursor()
+	if cur.X != 5 || cur.Y != 5 {
+		t.Errorf("non-ASCII in CSI moved cursor to (%d,%d), want (5,5)", cur.X, cur.Y)
 	}
 }
 

--- a/hardening_test.go
+++ b/hardening_test.go
@@ -1,0 +1,112 @@
+package vt10x
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+// TestNewZeroSizeNoPanic ensures constructing a terminal with a zero size does not panic. resize(0,0) is a no-op so the
+// internal state stays at cols=0/rows=0; reset() must tolerate that.
+func TestNewZeroSizeNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("New(WithSize(0,0)) panicked: %v", r)
+		}
+	}()
+
+	vt := New(WithSize(0, 0))
+	cols, rows := vt.Size()
+	if cols != 0 || rows != 0 {
+		t.Fatalf("expected 0x0 terminal, got %dx%d", cols, rows)
+	}
+}
+
+// TestResizeRejectsExtremeSizes ensures pathological resize requests are  rejected rather than blindly allocating
+// terabytes. The library is used to replay untrusted session recordings, so a malformed resize event must not be able
+// to OOM the auth server.
+func TestResizeRejectsExtremeSizes(t *testing.T) {
+	cases := []struct{ cols, rows int }{
+		{math.MaxInt, math.MaxInt},
+		{math.MaxInt, 24},
+		{80, math.MaxInt},
+		{maxResizeDim + 1, 24},
+		{80, maxResizeDim + 1},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%dx%d", tc.cols, tc.rows), func(t *testing.T) {
+			vt := New(WithSize(80, 24))
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				vt.Resize(tc.cols, tc.rows)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Resize(%d,%d) did not return", tc.cols, tc.rows)
+			}
+
+			cols, rows := vt.Size()
+			if cols > maxResizeDim || rows > maxResizeDim {
+				t.Fatalf("Resize(%d,%d) produced %dx%d, exceeds cap %d",
+					tc.cols, tc.rows, cols, rows, maxResizeDim)
+			}
+		})
+	}
+}
+
+// FuzzWrite throws arbitrary bytes at a freshly constructed terminal and  fails on any panic. This is the safety net
+// for session-recording replay: a corrupt/truncated stream from a misbehaving storage backend must not  be able to
+// crash auth.
+func FuzzWrite(f *testing.F) {
+	seeds := []string{
+		// Plain text.
+		"hello world",
+		// Known previously-panicking CSI sequences.
+		"\x1b[-1@",
+		"\x1b[-1P",
+		"\x1b[9223372036854775807@",
+		"\x1b[9223372036854775807P",
+		"\x1b[1;1H\x1b[9223372036854775807I",
+		"\x1b[1;80H\x1b[9223372036854775807Z",
+		// Long runs of CSI parameters.
+		"\x1b[1;2;3;4;5;6;7;8;9;10;11;12;13;14H",
+		// OSC color commands.
+		"\x1b]4;1;rgb:ff/00/00\x07",
+		// Mixed printable + control.
+		"abc\x1b[31mred\x1b[0m\x1b[2J\x1b[H",
+		// Tab stops + resize sequences.
+		"\x1bH\x1b[8;24;80t",
+	}
+
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		vt := New(WithSize(80, 24))
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("Write(%q) panicked: %v", data, r)
+				}
+			}()
+
+			_, _ = vt.Write(data)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Write(%q) did not complete within timeout", data)
+		}
+	})
+}

--- a/ioctl_other.go
+++ b/ioctl_other.go
@@ -1,3 +1,4 @@
+//go:build plan9 || nacl || windows
 // +build plan9 nacl windows
 
 package vt10x
@@ -10,6 +11,6 @@ func ioctl(f *os.File, cmd, p uintptr) error {
 	return nil
 }
 
-func ResizePty(*os.File) error {
+func ResizePty(*os.File, int, int) error {
 	return nil
 }

--- a/parse.go
+++ b/parse.go
@@ -13,7 +13,7 @@ func (t *State) parse(c rune) {
 	}
 	// TODO: update selection; see st.c:2450
 
-	if t.mode&ModeWrap != 0 && t.cur.State&cursorWrapNext != 0 {
+	if t.mode&ModeWrap != 0 && t.cur.State&cursorWrapNext != 0 && t.cur.Y >= 0 && t.cur.Y < len(t.lines) && t.cur.X >= 0 && t.cur.X < len(t.lines[t.cur.Y]) {
 		t.lines[t.cur.Y][t.cur.X].Mode |= attrWrap
 		t.newline(true)
 	}
@@ -64,7 +64,9 @@ func (t *State) parseEsc(c rune) {
 	case 'E': // NEL - next line
 		t.newline(true)
 	case 'H': // HTS - horizontal tab stop
-		t.tabs[t.cur.X] = true
+		if t.cur.X >= 0 && t.cur.X < len(t.tabs) {
+			t.tabs[t.cur.X] = true
+		}
 	case 'M': // RI - reverse index
 		if t.cur.Y == t.top {
 			t.scrollDown(t.top, 1)
@@ -92,6 +94,9 @@ func (t *State) parseEsc(c rune) {
 
 func (t *State) parseEscCSI(c rune) {
 	if t.handleControlCodes(c) {
+		return
+	}
+	if c > 0x7F {
 		return
 	}
 	t.logf("%q", string(c))

--- a/recover.go
+++ b/recover.go
@@ -1,0 +1,13 @@
+package vt10x
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+// recoverTo converts a recovered panic into an error written to *err, including a stack trace.
+func recoverTo(err *error) {
+	if r := recover(); r != nil {
+		*err = fmt.Errorf("vt10x: recovered panic: %v\n%s", r, debug.Stack())
+	}
+}

--- a/state.go
+++ b/state.go
@@ -143,6 +143,9 @@ type State struct {
 }
 
 func newState(w io.Writer) *State {
+	if w == nil {
+		w = io.Discard
+	}
 	return &State{
 		w:             w,
 		colorOverride: make(map[Color]Color),
@@ -250,10 +253,16 @@ func (t *State) restoreCursor() {
 }
 
 func (t *State) put(c rune) {
+	if t.state == nil {
+		return
+	}
 	t.state(c)
 }
 
 func (t *State) putTab(forward bool) {
+	if t.cols <= 0 || len(t.tabs) == 0 {
+		return
+	}
 	x := t.cur.X
 	if forward {
 		if x == t.cols {
@@ -301,6 +310,9 @@ var gfxCharTable = [62]rune{
 }
 
 func (t *State) setChar(c rune, attr *Glyph, x, y int) {
+	if attr == nil || y < 0 || y >= len(t.lines) || x < 0 || y >= len(t.dirty) || x >= len(t.lines[y]) {
+		return
+	}
 	if attr.Mode&attrGfx != 0 {
 		if c >= 0x41 && c <= 0x7e && gfxCharTable[c-0x41] != 0 {
 			c = gfxCharTable[c-0x41]
@@ -310,7 +322,7 @@ func (t *State) setChar(c rune, attr *Glyph, x, y int) {
 	t.dirty[y] = true
 	t.lines[y][x] = *attr
 	t.lines[y][x].Char = c
-	//if t.options.BrightBold && attr.Mode&attrBold != 0 && attr.FG < 8 {
+	// if t.options.BrightBold && attr.Mode&attrBold != 0 && attr.FG < 8 {
 	if attr.Mode&attrBold != 0 && attr.FG < 8 {
 		t.lines[y][x].FG = attr.FG + 8
 	}
@@ -407,6 +419,9 @@ func (t *State) resize(cols, rows int) bool {
 }
 
 func (t *State) clear(x0, y0, x1, y1 int) {
+	if t.cols <= 0 || t.rows <= 0 || len(t.lines) == 0 || len(t.dirty) == 0 {
+		return
+	}
 	if x0 > x1 {
 		x0, x1 = x1, x0
 	}
@@ -439,6 +454,13 @@ func (t *State) moveAbsTo(x, y int) {
 }
 
 func (t *State) moveTo(x, y int) {
+	if t.cols <= 0 || t.rows <= 0 {
+		t.changed |= ChangedScreen
+		t.cur.State &^= cursorWrapNext
+		t.cur.X = 0
+		t.cur.Y = 0
+		return
+	}
 	var miny, maxy int
 	if t.cur.State&cursorOrigin != 0 {
 		miny = t.top
@@ -463,12 +485,20 @@ func (t *State) swapScreen() {
 
 func (t *State) dirtyAll() {
 	t.changed |= ChangedScreen
+	if len(t.dirty) == 0 {
+		return
+	}
 	for y := 0; y < t.rows; y++ {
 		t.dirty[y] = true
 	}
 }
 
 func (t *State) setScroll(top, bottom int) {
+	if t.rows <= 0 {
+		t.top = 0
+		t.bottom = 0
+		return
+	}
 	top = clamp(top, 0, t.rows-1)
 	bottom = clamp(bottom, 0, t.rows-1)
 	if top > bottom {
@@ -509,7 +539,13 @@ func between(val, min, max int) bool {
 }
 
 func (t *State) scrollDown(orig, n int) {
+	if t.rows <= 0 || t.cols <= 0 || len(t.lines) == 0 || len(t.dirty) == 0 || n <= 0 {
+		return
+	}
 	n = clamp(n, 0, t.bottom-orig+1)
+	if n == 0 {
+		return
+	}
 	t.clear(0, t.bottom-n+1, t.cols-1, t.bottom)
 	t.changed |= ChangedScreen
 	for i := t.bottom; i >= orig+n; i-- {
@@ -522,7 +558,13 @@ func (t *State) scrollDown(orig, n int) {
 }
 
 func (t *State) scrollUp(orig, n int) {
+	if t.rows <= 0 || t.cols <= 0 || len(t.lines) == 0 || len(t.dirty) == 0 || n <= 0 {
+		return
+	}
 	n = clamp(n, 0, t.bottom-orig+1)
+	if n == 0 {
+		return
+	}
 	t.clear(0, orig, t.cols-1, orig+n-1)
 	t.changed |= ChangedScreen
 	for i := orig; i <= t.bottom-n; i++ {
@@ -740,6 +782,9 @@ func (t *State) setAttr(attr []int) {
 }
 
 func (t *State) insertBlanks(n int) {
+	if t.cols <= 0 || t.rows <= 0 || t.cur.Y < 0 || t.cur.Y >= len(t.lines) || t.cur.Y >= len(t.dirty) {
+		return
+	}
 	// Clamp: CSI args are untrusted; prevent negative or overflowing slice bounds below.
 	n = clamp(n, 0, t.cols-t.cur.X)
 	src := t.cur.X
@@ -771,6 +816,9 @@ func (t *State) deleteLines(n int) {
 }
 
 func (t *State) deleteChars(n int) {
+	if t.cols <= 0 || t.rows <= 0 || t.cur.Y < 0 || t.cur.Y >= len(t.lines) || t.cur.Y >= len(t.dirty) {
+		return
+	}
 	// Clamp: CSI args are untrusted; prevent negative or overflowing slice bounds below.
 	n = clamp(n, 0, t.cols-t.cur.X)
 	src := t.cur.X + n

--- a/state.go
+++ b/state.go
@@ -8,6 +8,10 @@ import (
 
 const (
 	tabspaces = 8
+
+	// maxResizeDim caps resize dimensions so a pathological session recording can't OOM the host by requesting a
+	// terabyte-sized terminal.
+	maxResizeDim = 2048
 )
 
 const (
@@ -178,7 +182,11 @@ func (t *State) Unlock() {
 
 // Cell returns the glyph containing the character code, foreground color, and
 // background color at position (x, y) relative to the top left of the terminal.
+// Out-of-range coordinates return a zero Glyph rather than panicking.
 func (t *State) Cell(x, y int) Glyph {
+	if y < 0 || y >= len(t.lines) || x < 0 || x >= len(t.lines[y]) {
+		return Glyph{}
+	}
 	cell := t.lines[y][x]
 	fg, ok := t.colorOverride[cell.FG]
 	if ok {
@@ -331,7 +339,11 @@ func (t *State) reset() {
 	t.top = 0
 	t.bottom = t.rows - 1
 	t.mode = ModeWrap
-	t.clear(0, 0, t.rows-1, t.cols-1)
+	// Skip clear on an uninitialized (0x0) terminal: clear would compute a
+	// negative y range (rows-1 == -1) and then try to write to t.dirty[-1].
+	if t.cols > 0 && t.rows > 0 {
+		t.clear(0, 0, t.rows-1, t.cols-1)
+	}
 	t.moveTo(0, 0)
 }
 
@@ -340,7 +352,7 @@ func (t *State) resize(cols, rows int) bool {
 	if cols == t.cols && rows == t.rows {
 		return false
 	}
-	if cols < 1 || rows < 1 {
+	if !between(cols, 1, maxResizeDim) || !between(rows, 1, maxResizeDim) {
 		return false
 	}
 	slide := t.cur.Y - rows + 1
@@ -728,6 +740,8 @@ func (t *State) setAttr(attr []int) {
 }
 
 func (t *State) insertBlanks(n int) {
+	// Clamp: CSI args are untrusted; prevent negative or overflowing slice bounds below.
+	n = clamp(n, 0, t.cols-t.cur.X)
 	src := t.cur.X
 	dst := src + n
 	size := t.cols - dst
@@ -757,6 +771,8 @@ func (t *State) deleteLines(n int) {
 }
 
 func (t *State) deleteChars(n int) {
+	// Clamp: CSI args are untrusted; prevent negative or overflowing slice bounds below.
+	n = clamp(n, 0, t.cols-t.cur.X)
 	src := t.cur.X + n
 	dst := t.cur.X
 	size := t.cols - src

--- a/state_csi_args_test.go
+++ b/state_csi_args_test.go
@@ -1,0 +1,157 @@
+package vt10x
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+// TestCSICharOpsBadArg ensures insertBlanks and deleteChars do not panic on malformed CSI arguments (negative values or
+// values large enough to cause signed integer overflow in dst = cur.X + n or src = cur.X + n).
+func TestCSICharOpsBadArg(t *testing.T) {
+	ns := []struct {
+		name string
+		n    int
+	}{
+		{"negative small", -1},
+		{"negative large", -1_000_000},
+		{"zero", 0},
+		{"one", 1},
+		{"at cols", 80},
+		{"just past cols", 81},
+		{"much past cols", 1_000_000},
+		{"max int overflow", math.MaxInt},
+		{"min int underflow", math.MinInt},
+	}
+
+	ops := []struct {
+		name string
+		fn   func(*State, int)
+	}{
+		{"insertBlanks", (*State).insertBlanks},
+		{"deleteChars", (*State).deleteChars},
+	}
+
+	for _, op := range ops {
+		for _, tc := range ns {
+			t.Run(op.name+"/"+tc.name, func(t *testing.T) {
+				s := newState(nil)
+				s.resize(80, 24)
+				s.reset()
+				s.moveTo(5, 5)
+
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("%s(%d) panicked: %v", op.name, tc.n, r)
+					}
+				}()
+
+				op.fn(s, tc.n)
+			})
+		}
+	}
+}
+
+// TestCSITabLoopsBounded ensures CHT (CSI I) and CBT (CSI Z) don't spin the goroutine when given a pathologically large
+// argument. putTab is bounded by cols, so looping more than cols times is wasted work; an adversarial stream with
+// INT_MAX wouldn't panic but would hang the processor.
+func TestCSITabLoopsBounded(t *testing.T) {
+	sequences := []string{
+		// Move to (1, 1), then CHT with INT_MAX.
+		fmt.Sprintf("\x1b[1;1H\x1b[%dI", math.MaxInt),
+		// Move to last column, then CBT with INT_MAX.
+		fmt.Sprintf("\x1b[1;80H\x1b[%dZ", math.MaxInt),
+	}
+
+	for _, seq := range sequences {
+		t.Run(fmt.Sprintf("%q", seq), func(t *testing.T) {
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				vt := New()
+				vt.Resize(80, 24)
+				_, _ = vt.Write([]byte(seq))
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("Write(%q) did not complete within timeout", seq)
+			}
+		})
+	}
+}
+
+// TestCellOutOfBounds ensures Cell returns a zero Glyph rather than panicking when given out-of-range coordinates.
+// This makes the library safe-by-default for downstream callers that might otherwise trust an externally-supplied offset.
+func TestCellOutOfBounds(t *testing.T) {
+	s := newState(nil)
+	s.resize(80, 24)
+	s.reset()
+
+	cases := []struct{ x, y int }{
+		{-1, 0},
+		{0, -1},
+		{-1, -1},
+		{80, 0},
+		{0, 24},
+		{80, 24},
+		{1_000_000, 0},
+		{0, 1_000_000},
+		{math.MaxInt, math.MaxInt},
+		{math.MinInt, math.MinInt},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d,%d", tc.x, tc.y), func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Cell(%d,%d) panicked: %v", tc.x, tc.y, r)
+				}
+			}()
+
+			got := s.Cell(tc.x, tc.y)
+			if got != (Glyph{}) {
+				t.Fatalf("Cell(%d,%d) = %+v, want zero Glyph", tc.x, tc.y, got)
+			}
+		})
+	}
+}
+
+// TestWriteMalformedCSINoPanic feeds malformed CSI sequences through the public Write path and asserts they do not
+// panic. Malformed CSI args (negative, overflow) reaching insertBlanks / deleteChars must be clamped, not trusted as
+// slice bounds.
+func TestWriteMalformedCSINoPanic(t *testing.T) {
+	// 'P' = DCH (delete chars), '@' = ICH (insert chars).
+	sequences := []string{
+		"\x1b[-1@",
+		"\x1b[-1P",
+		"\x1b[0@",
+		"\x1b[0P",
+		fmt.Sprintf("\x1b[%d@", math.MaxInt),
+		fmt.Sprintf("\x1b[%d@", math.MaxInt64),
+		fmt.Sprintf("\x1b[%dP", math.MaxInt),
+		fmt.Sprintf("\x1b[%dP", math.MaxInt64),
+		// Position cursor near the right margin, then attempt large insert/delete.
+		"\x1b[1;79H\x1b[999999@",
+		"\x1b[1;79H\x1b[999999P",
+	}
+
+	for _, seq := range sequences {
+		t.Run(fmt.Sprintf("%q", seq), func(t *testing.T) {
+			vt := New()
+			vt.Resize(80, 24)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Write(%q) panicked: %v", seq, r)
+				}
+			}()
+
+			if _, err := vt.Write([]byte(seq)); err != nil {
+				t.Fatalf("Write(%q) returned error: %v", seq, err)
+			}
+		})
+	}
+}

--- a/str.go
+++ b/str.go
@@ -75,11 +75,11 @@ func (t *State) handleSTR() {
 			}
 
 			c := s.argString(1, "")
-			p := &c
-			if p != nil && *p == "?" {
+
+			if c == "?" {
 				t.oscColorResponse(int(DefaultFG), 10)
-			} else if err := t.setColorName(int(DefaultFG), p); err != nil {
-				t.logf("invalid foreground color: %s\n", maybe(p))
+			} else if err := t.setColorName(int(DefaultFG), &c); err != nil {
+				t.logf("invalid foreground color: %s\n", maybe(&c))
 			} else {
 				// TODO: redraw
 			}
@@ -89,11 +89,10 @@ func (t *State) handleSTR() {
 			}
 
 			c := s.argString(1, "")
-			p := &c
-			if p != nil && *p == "?" {
+			if c == "?" {
 				t.oscColorResponse(int(DefaultBG), 11)
-			} else if err := t.setColorName(int(DefaultBG), p); err != nil {
-				t.logf("invalid cursor color: %s\n", maybe(p))
+			} else if err := t.setColorName(int(DefaultBG), &c); err != nil {
+				t.logf("invalid cursor color: %s\n", maybe(&c))
 			} else {
 				// TODO: redraw
 			}
@@ -157,6 +156,9 @@ func (t *State) setColorName(j int, p *string) error {
 	if !between(j, 0, 1<<24) {
 		return fmt.Errorf("invalid color value %d", j)
 	}
+	if t.colorOverride == nil {
+		t.colorOverride = make(map[Color]Color)
+	}
 
 	if p == nil {
 		// restore color
@@ -174,6 +176,9 @@ func (t *State) setColorName(j int, p *string) error {
 }
 
 func (t *State) oscColorResponse(j, num int) {
+	if t.w == nil {
+		return
+	}
 	if j < 0 {
 		t.logf("failed to fetch osc color %d\n", j)
 		return
@@ -189,6 +194,9 @@ func (t *State) oscColorResponse(j, num int) {
 }
 
 func (t *State) osc4ColorResponse(j int) {
+	if t.w == nil {
+		return
+	}
 	if j < 0 {
 		t.logf("failed to fetch osc4 color %d\n", j)
 		return

--- a/vt.go
+++ b/vt.go
@@ -70,6 +70,9 @@ type TerminalInfo struct {
 
 func WithWriter(w io.Writer) TerminalOption {
 	return func(info *TerminalInfo) {
+		if w == nil {
+			return
+		}
 		info.w = w
 	}
 }

--- a/vt_other.go
+++ b/vt_other.go
@@ -1,3 +1,4 @@
+//go:build plan9 || nacl || windows
 // +build plan9 nacl windows
 
 package vt10x
@@ -29,7 +30,11 @@ func (t *terminal) init(cols, rows int) {
 	t.reset()
 }
 
-func (t *terminal) Write(p []byte) (int, error) {
+// Write parses input and writes terminal changes to state.
+// Panics from malformed input are recovered and returned as an error; mutex state unwinds safely because every lock uses defer.
+func (t *terminal) Write(p []byte) (n int, err error) {
+	defer recoverTo(&err)
+
 	var written int
 	r := bytes.NewReader(p)
 	t.lock()
@@ -57,7 +62,9 @@ func (t *terminal) Write(p []byte) (int, error) {
 }
 
 // WriteWithChanges writes to the terminal state and returns the line numbers that changed.
-func (t *terminal) WriteWithChanges(p []byte) ([]int, error) {
+func (t *terminal) WriteWithChanges(p []byte) (lines []int, err error) {
+	defer recoverTo(&err)
+
 	var dirtyLines = make(map[int]bool)
 	var written int
 	r := bytes.NewReader(p)
@@ -87,7 +94,9 @@ func (t *terminal) WriteWithChanges(p []byte) ([]int, error) {
 }
 
 // TODO: add tests for expected blocking behavior
-func (t *terminal) Parse(br *bufio.Reader) error {
+func (t *terminal) Parse(br *bufio.Reader) (err error) {
+	defer recoverTo(&err)
+
 	var locked bool
 	defer func() {
 		if locked {

--- a/vt_posix.go
+++ b/vt_posix.go
@@ -31,7 +31,9 @@ func (t *terminal) init(cols, rows int) {
 }
 
 // Write parses input and writes terminal changes to state.
-func (t *terminal) Write(p []byte) (int, error) {
+// Panics from malformed input are recovered and returned as an error; mutex state unwinds safely because every lock uses defer.
+func (t *terminal) Write(p []byte) (n int, err error) {
+	defer recoverTo(&err)
 	var written int
 	r := bytes.NewReader(p)
 	t.lock()
@@ -59,7 +61,8 @@ func (t *terminal) Write(p []byte) (int, error) {
 }
 
 // WriteWithChanges writes to the terminal state and returns the line numbers that changed.
-func (t *terminal) WriteWithChanges(p []byte) ([]int, error) {
+func (t *terminal) WriteWithChanges(p []byte) (lines []int, err error) {
+	defer recoverTo(&err)
 	var dirtyLines = make(map[int]bool)
 	r := bytes.NewReader(p)
 	t.lock()
@@ -114,7 +117,8 @@ func uniqueSorted(m map[int]bool) []int {
 }
 
 // TODO: add tests for expected blocking behavior
-func (t *terminal) Parse(br *bufio.Reader) error {
+func (t *terminal) Parse(br *bufio.Reader) (err error) {
+	defer recoverTo(&err)
 	var locked bool
 	defer func() {
 		if locked {

--- a/vt_test.go
+++ b/vt_test.go
@@ -62,3 +62,136 @@ func TestNewline(t *testing.T) {
 		t.Fatal(st.cur.X, st.cur.Y, attr.FG, attr.BG)
 	}
 }
+
+func FuzzTerminal(f *testing.F) {
+	testcases := []string{
+		// plain text
+		"Hello, world", " ", "!12345",
+		// cursor movement
+		"\033[A", "\033[B", "\033[C", "\033[D",
+		"\033[10;5H", "\033[2J", "\033[K",
+		// SGR colors and attributes
+		"\033[1;31mRed Bold\033[0m",
+		"\033[38;5;196mColor256\033[m",
+		"\033[38;2;255;128;0mRGB\033[m",
+		// common PTY sequences
+		"\033[?1049h\033[?1049l", // alt screen on/off
+		"\033[?25l\033[?25h",     // cursor hide/show
+		"\033[?1h\033[?1l",       // application cursor keys
+		"\033(B\033)0",           // charset designation
+		// scroll regions and insert/delete
+		"\033[5;20r", "\033[1L", "\033[1M", "\033[1P", "\033[1@",
+		// window title and OSC
+		"\033]0;title\007",
+		"\033]2;window\033\\",
+		// control characters
+		"\r\n", "\t", "\b", "\007",
+		// UTF-8
+		"こんにちは", "你好", "🐹",
+		// erase display: all variants (J)
+		"\033[0J", "\033[1J", "\033[2J", "\033[3J",
+		// erase line: all variants (K)
+		"\033[0K", "\033[1K", "\033[2K",
+		// erase n chars (X)
+		"\033[5X", "\033[0X",
+		// cursor next/prev line (E, F)
+		"\033[3E", "\033[3F",
+		// vertical position absolute (d)
+		"\033[12d",
+		// horizontal position absolute (G, `)
+		"\033[40G", "\033[40`",
+		// tab stop set/clear (ESC H, CSI g)
+		"\033H", "\033[0g", "\033[3g",
+		// scroll up/down (S, T)
+		"\033[3S", "\033[3T",
+		// insert/delete lines (L, M)
+		"\033[5L", "\033[5M",
+		// index / reverse index / next line (ESC D, M, E)
+		"\033D", "\033M", "\033E",
+		// full reset (ESC c)
+		"\033c",
+		// save/restore cursor (ESC 7/8 and CSI s/u)
+		"\0337", "\0338", "\033[s", "\033[u",
+		// device status report / cursor position report (CSI n)
+		"\033[5n", "\033[6n",
+		// bracketed paste mode
+		"\033[?2004h\033[200~pasted text\033[201~\033[?2004l",
+		// focus events
+		"\033[?1004h", "\033[?1004l",
+		// mouse tracking modes
+		"\033[?1000h", "\033[?1002h", "\033[?1003h", "\033[?1006h",
+		"\033[?1000l", "\033[?1002l", "\033[?1003l", "\033[?1006l",
+		// DEC line drawing charset
+		"\033(0lqkxjmwuvt\033(B",
+		// realistic shell prompt
+		"\033[1;32muser@host\033[0m:\033[1;34m~/code\033[0m$ ",
+		// typical vim-style sequence: alt screen + cursor ops
+		"\033[?1049h\033[2J\033[H\033[?25l\033[?25h\033[?1049l",
+		// line wrap: write to last column to trigger wrap logic
+		"\033[1;80H" + "A" + "\033[1;1H",
+
+		// invalid: zero-size args
+		"\033[0@", "\033[0I", "\033[0Z",
+		// invalid: missing final byte (truncated CSI)
+		"\033[", "\033[1", "\033[1;",
+		// invalid: semicolons only
+		"\033[;H", "\033[;;H", "\033[;1H",
+		// invalid: unknown CSI final bytes
+		"\033[1q", "\033[1y", "\033[1~",
+		// invalid: unknown ESC sequences
+		"\033Q", "\033X", "\033^foo\007",
+		// invalid: scroll region inverted (bottom < top)
+		"\033[20;5r",
+		// invalid: large args for scroll, insert/delete lines, erase
+		"\033[999999S", "\033[999999T",
+		"\033[999999L", "\033[999999M",
+		"\033[999999X",
+		// previously-panicking: insertBlanks/deleteChars with negative args
+		"\x1b[-1@", "\x1b[-1P",
+		// previously-panicking: insertBlanks/deleteChars with int64 overflow
+		"\x1b[9223372036854775807@", "\x1b[9223372036854775807P",
+		// previously-panicking: CHT/CBT with MaxInt causing infinite loop
+		"\x1b[1;1H\x1b[9223372036854775807I",
+		"\x1b[1;80H\x1b[9223372036854775807Z",
+		// cursor near right margin + large insert/delete
+		"\x1b[1;79H\x1b[999999@", "\x1b[1;79H\x1b[999999P",
+		// invalid: OSC without terminator
+		"\033]0;unterminated title",
+		// invalid: CSI buffer overflow (>256 bytes)
+		"\033[" + strings.Repeat("1;", 130) + "H",
+		// invalid: null bytes embedded
+		"\x1b[1;1H\x00\x00text\x00",
+		// invalid: negative CUP coords
+		"\x1b[-5;-5H",
+		// invalid: VPA past screen
+		"\033[9999d",
+
+		// write-back paths: OSC color queries and DSR/CPR
+		// FuzzTerminal uses New() with ioutil.Discard so no nil-writer panic here;
+		// seeds exercise the OSC/DSR/CPR code paths for general coverage
+		"\033]10;?\007",          // OSC fg color query
+		"\033]11;?\007",          // OSC bg color query
+		"\033]4;1;?\007",         // OSC palette color query
+		"\033[5n",                // DSR
+		"\033[6n",                // CPR
+		// arithmetic overflow: INT_MAX arg for each cursor/erase command
+		"\033[9223372036854775807X", // ECH INT_MAX
+		"\033[9223372036854775807A", // CUU INT_MAX
+		"\033[9223372036854775807B", // CUD INT_MAX
+		"\033[9223372036854775807C", // CUF INT_MAX
+		"\033[9223372036854775807D", // CUB INT_MAX
+		"\033[0d",                   // VPA arg=0
+		// non-ASCII byte inside CSI (U+0148 low byte = 'H' = CUP without fix)
+		"\033[\xc5\x88",
+	}
+	for _, tc := range testcases {
+		f.Add([]byte(tc))
+	}
+	terminal := New()
+	f.Fuzz(func(t *testing.T, orig []byte) {
+		_, err := terminal.Write(orig)
+		if err != nil {
+			t.Fatalf("error not expected, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This hardens the emulator so malformed or malicious CSI streams can't panic, hang, or OOM the auth server during session recording processing.

- Clamps CSI args to valid slice bounds in `insertBlanks`/`deleteChars`
  - Before, these would use the CSI argument (`n`) directly as an index into the slice, so negative/huge/out-of-bound values could cause a panic
- Bounds CHT/CBT tab loops (`CSI n I` / `CSI n Z`) by `cols`
  - Before, the loop ran the full `n` iterations even though `putTab` stops at the margin, so a huge `n` could hang the write goroutine
- Adds some "hardening" tests - zero-size construction, extreme resize rejection (terminals are now capped at 2048x2048), fuzz testing with previously panic-causing inputs
- Adds tests around CSI arguments (bad/overflow values, bounded tab loops, `Cell` out-of-bounds, malformed CSI through `Write`)
- Adds GitHub actions workflow for running the tests on PRs/merges (removes the original repo's unused travis config)

Test runs before the changes

```
--- FAIL: TestCSICharOpsBadArg (0.00s)
    --- FAIL: TestCSICharOpsBadArg/insertBlanks/negative_small (0.00s)
        state_csi_args_test.go:46: insertBlanks(-1) panicked: runtime error: slice bounds out of range [:81] with capacity 80
    --- FAIL: TestCSICharOpsBadArg/insertBlanks/negative_large (0.00s)
        state_csi_args_test.go:46: insertBlanks(-1000000) panicked: runtime error: slice bounds out of range [-999995:]
    --- FAIL: TestCSICharOpsBadArg/insertBlanks/max_int_overflow (0.00s)
        state_csi_args_test.go:46: insertBlanks(9223372036854775807) panicked: runtime error: slice bounds out of range [-9223372036854775804:]
    --- FAIL: TestCSICharOpsBadArg/insertBlanks/min_int_underflow (0.00s)
        state_csi_args_test.go:46: insertBlanks(-9223372036854775808) panicked: runtime error: slice bounds out of range [-9223372036854775803:]
    --- FAIL: TestCSICharOpsBadArg/deleteChars/negative_small (0.00s)
        state_csi_args_test.go:46: deleteChars(-1) panicked: runtime error: slice bounds out of range [:81] with capacity 80
    --- FAIL: TestCSICharOpsBadArg/deleteChars/negative_large (0.00s)
        state_csi_args_test.go:46: deleteChars(-1000000) panicked: runtime error: slice bounds out of range [:1000080] with capacity 80
    --- FAIL: TestCSICharOpsBadArg/deleteChars/max_int_overflow (0.00s)
        state_csi_args_test.go:46: deleteChars(9223372036854775807) panicked: runtime error: slice bounds out of range [:-9223372036854775727]
    --- FAIL: TestCSICharOpsBadArg/deleteChars/min_int_underflow (0.00s)
        state_csi_args_test.go:46: deleteChars(-9223372036854775808) panicked: runtime error: slice bounds out of range [:-9223372036854775728]
--- FAIL: TestCellOutOfBounds (0.00s)
    --- FAIL: TestCellOutOfBounds/-1,0 (0.00s)
        state_csi_args_test.go:110: Cell(-1,0) panicked: runtime error: index out of range [-1]
    --- FAIL: TestCellOutOfBounds/0,-1 (0.00s)
        state_csi_args_test.go:110: Cell(0,-1) panicked: runtime error: index out of range [-1]
    --- FAIL: TestCellOutOfBounds/-1,-1 (0.00s)
        state_csi_args_test.go:110: Cell(-1,-1) panicked: runtime error: index out of range [-1]
    --- FAIL: TestCellOutOfBounds/80,0 (0.00s)
        state_csi_args_test.go:110: Cell(80,0) panicked: runtime error: index out of range [80] with length 80
    --- FAIL: TestCellOutOfBounds/0,24 (0.00s)
        state_csi_args_test.go:110: Cell(0,24) panicked: runtime error: index out of range [24] with length 24
    --- FAIL: TestCellOutOfBounds/80,24 (0.00s)
        state_csi_args_test.go:110: Cell(80,24) panicked: runtime error: index out of range [24] with length 24
    --- FAIL: TestCellOutOfBounds/1000000,0 (0.00s)
        state_csi_args_test.go:110: Cell(1000000,0) panicked: runtime error: index out of range [1000000] with length 80
    --- FAIL: TestCellOutOfBounds/0,1000000 (0.00s)
        state_csi_args_test.go:110: Cell(0,1000000) panicked: runtime error: index out of range [1000000] with length 24
    --- FAIL: TestCellOutOfBounds/9223372036854775807,9223372036854775807 (0.00s)
        state_csi_args_test.go:110: Cell(9223372036854775807,9223372036854775807) panicked: runtime error: index out of range [9223372036854775807] with length 24
    --- FAIL: TestCellOutOfBounds/-9223372036854775808,-9223372036854775808 (0.00s)
        state_csi_args_test.go:110: Cell(-9223372036854775808,-9223372036854775808) panicked: runtime error: index out of range [-9223372036854775808]
--- FAIL: TestWriteMalformedCSINoPanic (0.00s)
    --- FAIL: TestWriteMalformedCSINoPanic/"\x1b[-1@" (0.00s)
        state_csi_args_test.go:148: Write("\x1b[-1@") panicked: runtime error: slice bounds out of range [-1:]
    --- FAIL: TestWriteMalformedCSINoPanic/"\x1b[-1P" (0.00s)
        state_csi_args_test.go:148: Write("\x1b[-1P") panicked: runtime error: slice bounds out of range [:81] with capacity 80
--- FAIL: TestCSITabLoopsBounded (4.00s)
    --- FAIL: TestCSITabLoopsBounded/"\x1b[1;1H\x1b[9223372036854775807I" (2.00s)
        state_csi_args_test.go:80: Write("\x1b[1;1H\x1b[9223372036854775807I") did not complete within timeout
    --- FAIL: TestCSITabLoopsBounded/"\x1b[1;80H\x1b[9223372036854775807Z" (2.00s)
        state_csi_args_test.go:80: Write("\x1b[1;80H\x1b[9223372036854775807Z") did not complete within timeout
--- FAIL: TestResizeRejectsExtremeSizes
panic: runtime error: makeslice: len out of range

goroutine 22 [running]:
github.com/hinshun/vt10x.(*State).resize(0x140001384e0, 0x7fffffffffffffff, 0x7fffffffffffffff)
	/Users/ryan/go/src/remote/gravitational/vt10x/state.go:354 +0x170
github.com/hinshun/vt10x.(*terminal).Resize(0x1049d5f60?, 0x14000102e00?, 0x14000065788?)
	/Users/ryan/go/src/remote/gravitational/vt10x/vt_posix.go:163 +0xb8
github.com/hinshun/vt10x.TestResizeRejectsExtremeSizes.func1.1()
	/Users/ryan/go/src/remote/gravitational/vt10x/hardening_test.go:44 +0x50
created by github.com/hinshun/vt10x.TestResizeRejectsExtremeSizes.func1 in goroutine 21
	/Users/ryan/go/src/remote/gravitational/vt10x/hardening_test.go:42 +0xd8
exit status 2
--- FAIL: FuzzWrite (2.08s)
    --- FAIL: FuzzWrite (0.00s)
        hardening_test.go:99: Write("\x1b[-1P") panicked: runtime error: slice bounds out of range [:81] with capacity 80
```

After

```
go test -race ./...
ok  	github.com/hinshun/vt10x	1.207s
go test -run '^$' -fuzz='FuzzWrite' -fuzztime=30s
fuzz: elapsed: 0s, gathering baseline coverage: 0/492 completed
fuzz: elapsed: 0s, gathering baseline coverage: 492/492 completed, now fuzzing with 16 workers
fuzz: elapsed: 3s, execs: 672645 (224183/sec), new interesting: 14 (total: 506)
fuzz: elapsed: 6s, execs: 1338125 (221812/sec), new interesting: 25 (total: 517)
fuzz: elapsed: 9s, execs: 1789006 (150273/sec), new interesting: 30 (total: 522)
fuzz: elapsed: 12s, execs: 2250050 (153711/sec), new interesting: 34 (total: 526)
fuzz: elapsed: 15s, execs: 2555595 (101829/sec), new interesting: 37 (total: 529)
fuzz: elapsed: 18s, execs: 2653765 (32723/sec), new interesting: 38 (total: 530)
fuzz: elapsed: 21s, execs: 2726362 (24201/sec), new interesting: 39 (total: 531)
fuzz: elapsed: 24s, execs: 2787718 (20457/sec), new interesting: 39 (total: 531)
fuzz: elapsed: 27s, execs: 2823873 (12050/sec), new interesting: 39 (total: 531)
fuzz: elapsed: 30s, execs: 2823873 (0/sec), new interesting: 39 (total: 531)
fuzz: elapsed: 31s, execs: 2823873 (0/sec), new interesting: 39 (total: 531)
PASS
ok  	github.com/hinshun/vt10x	31.287s
```